### PR TITLE
Add frontend for analysis results

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,26 @@ The analysis generates several output files:
 - `word_cloud.png`: Word cloud of common themes
 - `overview_*.png`: Overview visualizations
 
+## Setting Up and Running the Frontend
+
+1. **Navigate to the frontend directory**:
+   ```bash
+   cd frontend
+   ```
+
+2. **Install frontend dependencies**:
+   ```bash
+   npm install
+   ```
+
+3. **Start the React application**:
+   ```bash
+   npm start
+   ```
+
+4. **Access the frontend**:
+   Open your browser and go to `http://localhost:3000` to view the analysis results in a user-friendly interface.
+
 ## Error Handling
 
 Each script includes error handling for common issues:

--- a/frontend-react/src/App.js
+++ b/frontend-react/src/App.js
@@ -1,0 +1,29 @@
+import React from 'react';
+import { BrowserRouter as Router, Route, Switch } from 'react-router-dom';
+import Overview from './components/Overview';
+import SentimentAnalysis from './components/SentimentAnalysis';
+import TemporalAnalysis from './components/TemporalAnalysis';
+import TopicModeling from './components/TopicModeling';
+import QueryClassification from './components/QueryClassification';
+import ResponseTimeAnalysis from './components/ResponseTimeAnalysis';
+import ConversationPatterns from './components/ConversationPatterns';
+
+function App() {
+  return (
+    <Router>
+      <div className="App">
+        <Switch>
+          <Route path="/overview" component={Overview} />
+          <Route path="/sentiment-analysis" component={SentimentAnalysis} />
+          <Route path="/temporal-analysis" component={TemporalAnalysis} />
+          <Route path="/topic-modeling" component={TopicModeling} />
+          <Route path="/query-classification" component={QueryClassification} />
+          <Route path="/response-time-analysis" component={ResponseTimeAnalysis} />
+          <Route path="/conversation-patterns" component={ConversationPatterns} />
+        </Switch>
+      </div>
+    </Router>
+  );
+}
+
+export default App;

--- a/frontend-react/src/components/ConversationPatterns.js
+++ b/frontend-react/src/components/ConversationPatterns.js
@@ -1,0 +1,54 @@
+import React, { useEffect, useState } from 'react';
+import axios from 'axios';
+
+const ConversationPatterns = () => {
+  const [patternData, setPatternData] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    const fetchPatternData = async () => {
+      try {
+        const response = await axios.get('/api/conversation-patterns');
+        setPatternData(response.data);
+        setLoading(false);
+      } catch (err) {
+        setError(err);
+        setLoading(false);
+      }
+    };
+
+    fetchPatternData();
+  }, []);
+
+  if (loading) {
+    return <div>Loading...</div>;
+  }
+
+  if (error) {
+    return <div>Error: {error.message}</div>;
+  }
+
+  return (
+    <div>
+      <h1>Conversation Pattern Analysis Results</h1>
+      {patternData && (
+        <div>
+          <h2>Top Recurring Themes</h2>
+          <ul>
+            {patternData['Top Themes'].map((theme, index) => (
+              <li key={index}>
+                {theme.word}: {theme.frequency} occurrences
+              </li>
+            ))}
+          </ul>
+
+          <h2>Word Cloud</h2>
+          <img src={patternData['Word Cloud']} alt="Word Cloud" />
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default ConversationPatterns;

--- a/frontend-react/src/components/Overview.js
+++ b/frontend-react/src/components/Overview.js
@@ -1,0 +1,66 @@
+import React, { useEffect, useState } from 'react';
+import axios from 'axios';
+
+const Overview = () => {
+  const [overviewData, setOverviewData] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    const fetchOverviewData = async () => {
+      try {
+        const response = await axios.get('/api/overview');
+        setOverviewData(response.data);
+        setLoading(false);
+      } catch (err) {
+        setError(err);
+        setLoading(false);
+      }
+    };
+
+    fetchOverviewData();
+  }, []);
+
+  if (loading) {
+    return <div>Loading...</div>;
+  }
+
+  if (error) {
+    return <div>Error: {error.message}</div>;
+  }
+
+  return (
+    <div>
+      <h1>Overview Analysis Results</h1>
+      {overviewData && (
+        <div>
+          <h2>Summary</h2>
+          <p>Total Interactions: {overviewData.Overview['Total Interactions']}</p>
+          <p>Unique Topics: {overviewData.Overview['Unique Topics']}</p>
+          <p>Query Categories: {overviewData.Overview['Query Categories']}</p>
+
+          <h2>Sentiment Analysis</h2>
+          <p>Positive Queries: {overviewData['Sentiment Analysis']['Positive Queries']}</p>
+          <p>Negative Queries: {overviewData['Sentiment Analysis']['Negative Queries']}</p>
+          <p>Neutral Queries: {overviewData['Sentiment Analysis']['Neutral Queries']}</p>
+
+          <h2>Response Times</h2>
+          <p>Average Response Time: {overviewData['Response Times']['Average Response Time']}</p>
+          <p>Fastest Response: {overviewData['Response Times']['Fastest Response']}</p>
+          <p>Slowest Response: {overviewData['Response Times']['Slowest Response']}</p>
+
+          <h2>Top Themes</h2>
+          <ul>
+            {overviewData['Top Themes'].map((theme, index) => (
+              <li key={index}>
+                {theme.word}: {theme.frequency} occurrences
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default Overview;

--- a/frontend-react/src/components/QueryClassification.js
+++ b/frontend-react/src/components/QueryClassification.js
@@ -1,0 +1,53 @@
+import React, { useEffect, useState } from 'react';
+import axios from 'axios';
+
+const QueryClassification = () => {
+  const [classificationData, setClassificationData] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    const fetchClassificationData = async () => {
+      try {
+        const response = await axios.get('/api/query-classification');
+        setClassificationData(response.data);
+        setLoading(false);
+      } catch (err) {
+        setError(err);
+        setLoading(false);
+      }
+    };
+
+    fetchClassificationData();
+  }, []);
+
+  if (loading) {
+    return <div>Loading...</div>;
+  }
+
+  if (error) {
+    return <div>Error: {error.message}</div>;
+  }
+
+  return (
+    <div>
+      <h1>Query Classification Results</h1>
+      {classificationData && (
+        <div>
+          <h2>Query Categories</h2>
+          <ul>
+            {classificationData.map((item, index) => (
+              <li key={index}>
+                <strong>Query:</strong> {item.Query} <br />
+                <strong>Category:</strong> {item.Category} <br />
+                <strong>Keywords:</strong> {item.CategoryKeywords}
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default QueryClassification;

--- a/frontend-react/src/components/ResponseTimeAnalysis.js
+++ b/frontend-react/src/components/ResponseTimeAnalysis.js
@@ -1,0 +1,52 @@
+import React, { useEffect, useState } from 'react';
+import axios from 'axios';
+
+const ResponseTimeAnalysis = () => {
+  const [responseTimeData, setResponseTimeData] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    const fetchResponseTimeData = async () => {
+      try {
+        const response = await axios.get('/api/response-time-analysis');
+        setResponseTimeData(response.data);
+        setLoading(false);
+      } catch (err) {
+        setError(err);
+        setLoading(false);
+      }
+    };
+
+    fetchResponseTimeData();
+  }, []);
+
+  if (loading) {
+    return <div>Loading...</div>;
+  }
+
+  if (error) {
+    return <div>Error: {error.message}</div>;
+  }
+
+  return (
+    <div>
+      <h1>Response Time Analysis Results</h1>
+      {responseTimeData && (
+        <div>
+          <h2>Response Time Statistics</h2>
+          <p>Mean Response Time: {responseTimeData.mean} seconds</p>
+          <p>Median Response Time: {responseTimeData.median} seconds</p>
+          <p>Standard Deviation: {responseTimeData.std} seconds</p>
+          <p>Minimum Response Time: {responseTimeData.min} seconds</p>
+          <p>Maximum Response Time: {responseTimeData.max} seconds</p>
+
+          <h2>Response Time Distribution</h2>
+          <img src={responseTimeData.distribution} alt="Response Time Distribution" />
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default ResponseTimeAnalysis;

--- a/frontend-react/src/components/SentimentAnalysis.js
+++ b/frontend-react/src/components/SentimentAnalysis.js
@@ -1,0 +1,52 @@
+import React, { useEffect, useState } from 'react';
+import axios from 'axios';
+
+const SentimentAnalysis = () => {
+  const [sentimentData, setSentimentData] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    const fetchSentimentData = async () => {
+      try {
+        const response = await axios.get('/api/sentiment-analysis');
+        setSentimentData(response.data);
+        setLoading(false);
+      } catch (err) {
+        setError(err);
+        setLoading(false);
+      }
+    };
+
+    fetchSentimentData();
+  }, []);
+
+  if (loading) {
+    return <div>Loading...</div>;
+  }
+
+  if (error) {
+    return <div>Error: {error.message}</div>;
+  }
+
+  return (
+    <div>
+      <h1>Sentiment Analysis Results</h1>
+      {sentimentData && (
+        <div>
+          <h2>Query Sentiment Distribution</h2>
+          <p>Positive Queries: {sentimentData['Query Sentiment Distribution']['Positive']}</p>
+          <p>Negative Queries: {sentimentData['Query Sentiment Distribution']['Negative']}</p>
+          <p>Neutral Queries: {sentimentData['Query Sentiment Distribution']['Neutral']}</p>
+
+          <h2>Response Sentiment Distribution</h2>
+          <p>Positive Responses: {sentimentData['Response Sentiment Distribution']['Positive']}</p>
+          <p>Negative Responses: {sentimentData['Response Sentiment Distribution']['Negative']}</p>
+          <p>Neutral Responses: {sentimentData['Response Sentiment Distribution']['Neutral']}</p>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default SentimentAnalysis;

--- a/frontend-react/src/components/TemporalAnalysis.js
+++ b/frontend-react/src/components/TemporalAnalysis.js
@@ -1,0 +1,48 @@
+import React, { useEffect, useState } from 'react';
+import axios from 'axios';
+
+const TemporalAnalysis = () => {
+  const [temporalData, setTemporalData] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    const fetchTemporalData = async () => {
+      try {
+        const response = await axios.get('/api/temporal-analysis');
+        setTemporalData(response.data);
+        setLoading(false);
+      } catch (err) {
+        setError(err);
+        setLoading(false);
+      }
+    };
+
+    fetchTemporalData();
+  }, []);
+
+  if (loading) {
+    return <div>Loading...</div>;
+  }
+
+  if (error) {
+    return <div>Error: {error.message}</div>;
+  }
+
+  return (
+    <div>
+      <h1>Temporal Analysis Results</h1>
+      {temporalData && (
+        <div>
+          <h2>Interaction Frequency Over Time</h2>
+          <img src={temporalData['Interaction Frequency Over Time']} alt="Interaction Frequency Over Time" />
+
+          <h2>Engagement Trends (7-day Moving Average)</h2>
+          <img src={temporalData['Engagement Trends']} alt="Engagement Trends" />
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default TemporalAnalysis;

--- a/frontend-react/src/components/TopicModeling.js
+++ b/frontend-react/src/components/TopicModeling.js
@@ -1,0 +1,62 @@
+import React, { useEffect, useState } from 'react';
+import axios from 'axios';
+
+const TopicModeling = () => {
+  const [topicData, setTopicData] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    const fetchTopicData = async () => {
+      try {
+        const response = await axios.get('/api/topic-modeling');
+        setTopicData(response.data);
+        setLoading(false);
+      } catch (err) {
+        setError(err);
+        setLoading(false);
+      }
+    };
+
+    fetchTopicData();
+  }, []);
+
+  if (loading) {
+    return <div>Loading...</div>;
+  }
+
+  if (error) {
+    return <div>Error: {error.message}</div>;
+  }
+
+  return (
+    <div>
+      <h1>Topic Modeling Results</h1>
+      {topicData && (
+        <div>
+          <h2>Topics and Keywords</h2>
+          <ul>
+            {topicData.topics.map((topic, index) => (
+              <li key={index}>
+                <strong>Topic {index + 1}:</strong> {topic.words}
+              </li>
+            ))}
+          </ul>
+
+          <h2>Document Topics</h2>
+          <ul>
+            {topicData.documents.map((doc, index) => (
+              <li key={index}>
+                <strong>Query:</strong> {doc.Query} <br />
+                <strong>Topic:</strong> {doc.Topic} <br />
+                <strong>Probability:</strong> {doc.TopicProbability}
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default TopicModeling;

--- a/frontend-react/src/index.js
+++ b/frontend-react/src/index.js
@@ -1,0 +1,10 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import App from './App';
+
+ReactDOM.render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>,
+  document.getElementById('root')
+);

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1,0 +1,29 @@
+import React from 'react';
+import { BrowserRouter as Router, Route, Switch } from 'react-router-dom';
+import Overview from './components/Overview';
+import SentimentAnalysis from './components/SentimentAnalysis';
+import TemporalAnalysis from './components/TemporalAnalysis';
+import TopicModeling from './components/TopicModeling';
+import QueryClassification from './components/QueryClassification';
+import ResponseTimeAnalysis from './components/ResponseTimeAnalysis';
+import ConversationPatterns from './components/ConversationPatterns';
+
+function App() {
+  return (
+    <Router>
+      <div className="App">
+        <Switch>
+          <Route path="/overview" component={Overview} />
+          <Route path="/sentiment-analysis" component={SentimentAnalysis} />
+          <Route path="/temporal-analysis" component={TemporalAnalysis} />
+          <Route path="/topic-modeling" component={TopicModeling} />
+          <Route path="/query-classification" component={QueryClassification} />
+          <Route path="/response-time-analysis" component={ResponseTimeAnalysis} />
+          <Route path="/conversation-patterns" component={ConversationPatterns} />
+        </Switch>
+      </div>
+    </Router>
+  );
+}
+
+export default App;

--- a/frontend/src/components/ConversationPatterns.js
+++ b/frontend/src/components/ConversationPatterns.js
@@ -1,0 +1,54 @@
+import React, { useEffect, useState } from 'react';
+import axios from 'axios';
+
+const ConversationPatterns = () => {
+  const [patternData, setPatternData] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    const fetchPatternData = async () => {
+      try {
+        const response = await axios.get('/api/conversation-patterns');
+        setPatternData(response.data);
+        setLoading(false);
+      } catch (err) {
+        setError(err);
+        setLoading(false);
+      }
+    };
+
+    fetchPatternData();
+  }, []);
+
+  if (loading) {
+    return <div>Loading...</div>;
+  }
+
+  if (error) {
+    return <div>Error: {error.message}</div>;
+  }
+
+  return (
+    <div>
+      <h1>Conversation Pattern Analysis Results</h1>
+      {patternData && (
+        <div>
+          <h2>Top Recurring Themes</h2>
+          <ul>
+            {patternData['Top Themes'].map((theme, index) => (
+              <li key={index}>
+                {theme.word}: {theme.frequency} occurrences
+              </li>
+            ))}
+          </ul>
+
+          <h2>Word Cloud</h2>
+          <img src={patternData['Word Cloud']} alt="Word Cloud" />
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default ConversationPatterns;

--- a/frontend/src/components/Overview.js
+++ b/frontend/src/components/Overview.js
@@ -1,0 +1,66 @@
+import React, { useEffect, useState } from 'react';
+import axios from 'axios';
+
+const Overview = () => {
+  const [overviewData, setOverviewData] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    const fetchOverviewData = async () => {
+      try {
+        const response = await axios.get('/api/overview');
+        setOverviewData(response.data);
+        setLoading(false);
+      } catch (err) {
+        setError(err);
+        setLoading(false);
+      }
+    };
+
+    fetchOverviewData();
+  }, []);
+
+  if (loading) {
+    return <div>Loading...</div>;
+  }
+
+  if (error) {
+    return <div>Error: {error.message}</div>;
+  }
+
+  return (
+    <div>
+      <h1>Overview Analysis Results</h1>
+      {overviewData && (
+        <div>
+          <h2>Summary</h2>
+          <p>Total Interactions: {overviewData.Overview['Total Interactions']}</p>
+          <p>Unique Topics: {overviewData.Overview['Unique Topics']}</p>
+          <p>Query Categories: {overviewData.Overview['Query Categories']}</p>
+
+          <h2>Sentiment Analysis</h2>
+          <p>Positive Queries: {overviewData['Sentiment Analysis']['Positive Queries']}</p>
+          <p>Negative Queries: {overviewData['Sentiment Analysis']['Negative Queries']}</p>
+          <p>Neutral Queries: {overviewData['Sentiment Analysis']['Neutral Queries']}</p>
+
+          <h2>Response Times</h2>
+          <p>Average Response Time: {overviewData['Response Times']['Average Response Time']}</p>
+          <p>Fastest Response: {overviewData['Response Times']['Fastest Response']}</p>
+          <p>Slowest Response: {overviewData['Response Times']['Slowest Response']}</p>
+
+          <h2>Top Themes</h2>
+          <ul>
+            {overviewData['Top Themes'].map((theme, index) => (
+              <li key={index}>
+                {theme.word}: {theme.frequency} occurrences
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default Overview;

--- a/frontend/src/components/QueryClassification.js
+++ b/frontend/src/components/QueryClassification.js
@@ -1,0 +1,53 @@
+import React, { useEffect, useState } from 'react';
+import axios from 'axios';
+
+const QueryClassification = () => {
+  const [classificationData, setClassificationData] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    const fetchClassificationData = async () => {
+      try {
+        const response = await axios.get('/api/query-classification');
+        setClassificationData(response.data);
+        setLoading(false);
+      } catch (err) {
+        setError(err);
+        setLoading(false);
+      }
+    };
+
+    fetchClassificationData();
+  }, []);
+
+  if (loading) {
+    return <div>Loading...</div>;
+  }
+
+  if (error) {
+    return <div>Error: {error.message}</div>;
+  }
+
+  return (
+    <div>
+      <h1>Query Classification Results</h1>
+      {classificationData && (
+        <div>
+          <h2>Query Categories</h2>
+          <ul>
+            {classificationData.map((item, index) => (
+              <li key={index}>
+                <strong>Query:</strong> {item.Query} <br />
+                <strong>Category:</strong> {item.Category} <br />
+                <strong>Keywords:</strong> {item.CategoryKeywords}
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default QueryClassification;

--- a/frontend/src/components/ResponseTimeAnalysis.js
+++ b/frontend/src/components/ResponseTimeAnalysis.js
@@ -1,0 +1,52 @@
+import React, { useEffect, useState } from 'react';
+import axios from 'axios';
+
+const ResponseTimeAnalysis = () => {
+  const [responseTimeData, setResponseTimeData] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    const fetchResponseTimeData = async () => {
+      try {
+        const response = await axios.get('/api/response-time-analysis');
+        setResponseTimeData(response.data);
+        setLoading(false);
+      } catch (err) {
+        setError(err);
+        setLoading(false);
+      }
+    };
+
+    fetchResponseTimeData();
+  }, []);
+
+  if (loading) {
+    return <div>Loading...</div>;
+  }
+
+  if (error) {
+    return <div>Error: {error.message}</div>;
+  }
+
+  return (
+    <div>
+      <h1>Response Time Analysis Results</h1>
+      {responseTimeData && (
+        <div>
+          <h2>Response Time Statistics</h2>
+          <p>Mean Response Time: {responseTimeData.mean} seconds</p>
+          <p>Median Response Time: {responseTimeData.median} seconds</p>
+          <p>Standard Deviation: {responseTimeData.std} seconds</p>
+          <p>Minimum Response Time: {responseTimeData.min} seconds</p>
+          <p>Maximum Response Time: {responseTimeData.max} seconds</p>
+
+          <h2>Response Time Distribution</h2>
+          <img src={responseTimeData.distribution} alt="Response Time Distribution" />
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default ResponseTimeAnalysis;

--- a/frontend/src/components/SentimentAnalysis.js
+++ b/frontend/src/components/SentimentAnalysis.js
@@ -1,0 +1,52 @@
+import React, { useEffect, useState } from 'react';
+import axios from 'axios';
+
+const SentimentAnalysis = () => {
+  const [sentimentData, setSentimentData] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    const fetchSentimentData = async () => {
+      try {
+        const response = await axios.get('/api/sentiment-analysis');
+        setSentimentData(response.data);
+        setLoading(false);
+      } catch (err) {
+        setError(err);
+        setLoading(false);
+      }
+    };
+
+    fetchSentimentData();
+  }, []);
+
+  if (loading) {
+    return <div>Loading...</div>;
+  }
+
+  if (error) {
+    return <div>Error: {error.message}</div>;
+  }
+
+  return (
+    <div>
+      <h1>Sentiment Analysis Results</h1>
+      {sentimentData && (
+        <div>
+          <h2>Query Sentiment Distribution</h2>
+          <p>Positive Queries: {sentimentData['Query Sentiment Distribution']['Positive']}</p>
+          <p>Negative Queries: {sentimentData['Query Sentiment Distribution']['Negative']}</p>
+          <p>Neutral Queries: {sentimentData['Query Sentiment Distribution']['Neutral']}</p>
+
+          <h2>Response Sentiment Distribution</h2>
+          <p>Positive Responses: {sentimentData['Response Sentiment Distribution']['Positive']}</p>
+          <p>Negative Responses: {sentimentData['Response Sentiment Distribution']['Negative']}</p>
+          <p>Neutral Responses: {sentimentData['Response Sentiment Distribution']['Neutral']}</p>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default SentimentAnalysis;

--- a/frontend/src/components/TemporalAnalysis.js
+++ b/frontend/src/components/TemporalAnalysis.js
@@ -1,0 +1,48 @@
+import React, { useEffect, useState } from 'react';
+import axios from 'axios';
+
+const TemporalAnalysis = () => {
+  const [temporalData, setTemporalData] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    const fetchTemporalData = async () => {
+      try {
+        const response = await axios.get('/api/temporal-analysis');
+        setTemporalData(response.data);
+        setLoading(false);
+      } catch (err) {
+        setError(err);
+        setLoading(false);
+      }
+    };
+
+    fetchTemporalData();
+  }, []);
+
+  if (loading) {
+    return <div>Loading...</div>;
+  }
+
+  if (error) {
+    return <div>Error: {error.message}</div>;
+  }
+
+  return (
+    <div>
+      <h1>Temporal Analysis Results</h1>
+      {temporalData && (
+        <div>
+          <h2>Interaction Frequency Over Time</h2>
+          <img src={temporalData['Interaction Frequency Over Time']} alt="Interaction Frequency Over Time" />
+
+          <h2>Engagement Trends (7-day Moving Average)</h2>
+          <img src={temporalData['Engagement Trends']} alt="Engagement Trends" />
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default TemporalAnalysis;

--- a/frontend/src/components/TopicModeling.js
+++ b/frontend/src/components/TopicModeling.js
@@ -1,0 +1,62 @@
+import React, { useEffect, useState } from 'react';
+import axios from 'axios';
+
+const TopicModeling = () => {
+  const [topicData, setTopicData] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    const fetchTopicData = async () => {
+      try {
+        const response = await axios.get('/api/topic-modeling');
+        setTopicData(response.data);
+        setLoading(false);
+      } catch (err) {
+        setError(err);
+        setLoading(false);
+      }
+    };
+
+    fetchTopicData();
+  }, []);
+
+  if (loading) {
+    return <div>Loading...</div>;
+  }
+
+  if (error) {
+    return <div>Error: {error.message}</div>;
+  }
+
+  return (
+    <div>
+      <h1>Topic Modeling Results</h1>
+      {topicData && (
+        <div>
+          <h2>Topics and Keywords</h2>
+          <ul>
+            {topicData.topics.map((topic, index) => (
+              <li key={index}>
+                <strong>Topic {index + 1}:</strong> {topic.words}
+              </li>
+            ))}
+          </ul>
+
+          <h2>Document Topics</h2>
+          <ul>
+            {topicData.documents.map((doc, index) => (
+              <li key={index}>
+                <strong>Query:</strong> {doc.Query} <br />
+                <strong>Topic:</strong> {doc.Topic} <br />
+                <strong>Probability:</strong> {doc.TopicProbability}
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default TopicModeling;

--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -1,0 +1,10 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import App from './App';
+
+ReactDOM.render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>,
+  document.getElementById('root')
+);

--- a/overview_synthesis.py
+++ b/overview_synthesis.py
@@ -109,6 +109,70 @@ def get_visualization(filename):
     except Exception as e:
         return jsonify({'error': str(e)}), 404
 
+@app.route('/api/overview', methods=['GET'])
+def get_overview():
+    try:
+        analysis_data = load_analysis_data()
+        combined_df = combine_insights(analysis_data)
+        summary_report = generate_summary_report(combined_df, analysis_data['patterns'])
+        return jsonify(summary_report)
+    except Exception as e:
+        return jsonify({'error': str(e)}), 500
+
+@app.route('/api/sentiment-analysis', methods=['GET'])
+def get_sentiment_analysis():
+    try:
+        sentiment_data = pd.read_csv('sentiment_analysis.csv')
+        sentiment_dict = sentiment_data.to_dict(orient='records')
+        return jsonify(sentiment_dict)
+    except Exception as e:
+        return jsonify({'error': str(e)}), 500
+
+@app.route('/api/temporal-analysis', methods=['GET'])
+def get_temporal_analysis():
+    try:
+        temporal_data = pd.read_csv('temporal_analysis.csv')
+        temporal_dict = temporal_data.to_dict(orient='records')
+        return jsonify(temporal_dict)
+    except Exception as e:
+        return jsonify({'error': str(e)}), 500
+
+@app.route('/api/topic-modeling', methods=['GET'])
+def get_topic_modeling():
+    try:
+        topic_data = pd.read_csv('topic_modeling.csv')
+        topic_dict = topic_data.to_dict(orient='records')
+        return jsonify(topic_dict)
+    except Exception as e:
+        return jsonify({'error': str(e)}), 500
+
+@app.route('/api/query-classification', methods=['GET'])
+def get_query_classification():
+    try:
+        query_data = pd.read_csv('query_classification.csv')
+        query_dict = query_data.to_dict(orient='records')
+        return jsonify(query_dict)
+    except Exception as e:
+        return jsonify({'error': str(e)}), 500
+
+@app.route('/api/response-time-analysis', methods=['GET'])
+def get_response_time_analysis():
+    try:
+        response_time_data = pd.read_csv('response_time_analysis.csv')
+        response_time_dict = response_time_data.to_dict(orient='records')
+        return jsonify(response_time_dict)
+    except Exception as e:
+        return jsonify({'error': str(e)}), 500
+
+@app.route('/api/conversation-patterns', methods=['GET'])
+def get_conversation_patterns():
+    try:
+        patterns_data = pd.read_csv('conversation_patterns.csv')
+        patterns_dict = patterns_data.to_dict(orient='records')
+        return jsonify(patterns_dict)
+    except Exception as e:
+        return jsonify({'error': str(e)}), 500
+
 if __name__ == "__main__":
     try:
         # Load all analysis results

--- a/overview_synthesis.py
+++ b/overview_synthesis.py
@@ -1,5 +1,9 @@
 import pandas as pd
 import matplotlib.pyplot as plt
+import json
+from flask import Flask, jsonify
+
+app = Flask(__name__)
 
 def load_analysis_data():
     try:
@@ -88,6 +92,23 @@ def save_visualizations(combined_df):
     plt.savefig('overview_categories.png')
     plt.close()
 
+@app.route('/api/summary', methods=['GET'])
+def get_summary():
+    try:
+        analysis_data = load_analysis_data()
+        combined_df = combine_insights(analysis_data)
+        summary_report = generate_summary_report(combined_df, analysis_data['patterns'])
+        return jsonify(summary_report)
+    except Exception as e:
+        return jsonify({'error': str(e)}), 500
+
+@app.route('/api/visualizations/<filename>', methods=['GET'])
+def get_visualization(filename):
+    try:
+        return app.send_static_file(filename)
+    except Exception as e:
+        return jsonify({'error': str(e)}), 404
+
 if __name__ == "__main__":
     try:
         # Load all analysis results
@@ -115,6 +136,9 @@ if __name__ == "__main__":
         for theme in summary_report['Top Themes'][:5]:
             print(f"{theme['word']}: {theme['frequency']} occurrences")
             
+        # Run Flask app
+        app.run(debug=True, host='0.0.0.0', port=5000)
+        
     except FileNotFoundError as e:
         print(f"Error: {str(e)}")
         print("Please ensure all analysis scripts have been run in the correct order:")


### PR DESCRIPTION
Add a frontend using React to interface with existing Python scripts and display analysis results.

* **Frontend Setup**
  - Add `frontend/src/index.js` to render the main `App` component.
  - Add `frontend/src/App.js` to set up routing for different analysis result pages.
  - Add components for displaying various analysis results: `Overview.js`, `SentimentAnalysis.js`, `TemporalAnalysis.js`, `TopicModeling.js`, `QueryClassification.js`, `ResponseTimeAnalysis.js`, and `ConversationPatterns.js`.

* **Backend Updates**
  - Modify `overview_synthesis.py` to add endpoints serving analysis results as JSON using Flask.
  - Add routes for summary and visualizations.

* **Documentation**
  - Update `README.md` with instructions for setting up and running the frontend.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/liquescentremedies/chatgpt-interaction-analysis/pull/1?shareId=5fd1e69b-3035-42f4-b268-9997bd307107).